### PR TITLE
vehicle: Implement per-wheel brake torque

### DIFF
--- a/vphysics_jolt/vjolt_controller_vehicle.h
+++ b/vphysics_jolt/vjolt_controller_vehicle.h
@@ -83,6 +83,7 @@ private:
 
 	std::vector< JoltPhysicsWheel >			m_Wheels;
 
+	float									m_TotalWheelMass = 0.0f;
 	JoltPhysicsInternalVehicleState			m_InternalState;
 
 	JPH::Ref< JPH::VehicleConstraint >		m_VehicleConstraint;


### PR DESCRIPTION
Based upon the same calculations that regular VPhysics does, calculate the per-wheel brake torque.

Improves vehicle feel and matches it more closely.