### PR TITLE
listener: Fix a typo causing collision damage to be applied in full

### DIFF
--- a/vphysics_jolt/vjolt_listener_contact.h
+++ b/vphysics_jolt/vjolt_listener_contact.h
@@ -418,7 +418,7 @@ private:
 			// Unused...
 			, m_ContactSpeed( vec3_origin )
 			, m_Velocity0( pObject1->GetBody()->GetLinearVelocity() )
-			, m_Velocity1( pObject1->GetBody()->GetLinearVelocity() )
+			, m_Velocity1( pObject2->GetBody()->GetLinearVelocity() )
 		{
 		}
 


### PR DESCRIPTION
There was a typo in vjolt_listener_contact.h where it would get the velocity of the first object twice, which was wrong, and this was causing damage to be applied in full