### PR TITLE
Fix a couple of warnings

### DIFF
--- a/vphysics_jolt/vjolt_state_recorder_file.h
+++ b/vphysics_jolt/vjolt_state_recorder_file.h
@@ -11,7 +11,7 @@ public:
 
 	JoltStateRecorderFile( JoltStateRecorderFile &&other )
 		: StateRecorder( other )
-		, m_Stream( move( other.m_Stream ) )
+		, m_Stream( std::move( other.m_Stream ) )
 	{
 	}
 


### PR DESCRIPTION
A couple teeny little warning fixes:
* Fix format warning in vjolt_collide.cpp. Even though the code works fine, it trips `-Wformat` warnings in GCC/Clang.
* `move(x)` -> `std::move(x)` is to fix a dumb warning introduced with clang 16.