### PR TITLE
environment: Use resize when updating m_CachedObjects

### DIFF
--- a/vphysics_jolt/vjolt_environment.cpp
+++ b/vphysics_jolt/vjolt_environment.cpp
@@ -909,7 +909,7 @@ const IPhysicsObject **JoltPhysicsEnvironment::GetObjectList( int *pOutputObject
 	if ( pOutputObjectCount )
 		*pOutputObjectCount = nCount;
 
-	m_CachedObjects.reserve( nCount );
+	m_CachedObjects.resize( nCount );
 	for ( int i = 0; i < nCount; i++ )
 	{
 		JPH::Body *pBody = m_PhysicsSystem.GetBodyLockInterfaceNoLock().TryGetBody( m_CachedBodies[ i ] );


### PR DESCRIPTION
This was a typo, otherwise the size is always 0.