### PR TITLE
environment: Add list of dirty static bodies

### DIFF
--- a/vphysics_jolt/vjolt_constraints.cpp
+++ b/vphysics_jolt/vjolt_constraints.cpp
@@ -70,8 +70,7 @@ void JoltPhysicsConstraintGroup::AddConstraint( JoltPhysicsConstraint *pConstrai
 
 void JoltPhysicsConstraintGroup::RemoveConstraint( JoltPhysicsConstraint *pConstraint )
 {
-	m_pConstraints.erase(
-		std::remove_if( m_pConstraints.begin(), m_pConstraints.end(), [&]( JoltPhysicsConstraint *pOther ) { return pOther == pConstraint; } ) );
+	Erase( m_pConstraints, pConstraint );
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/vphysics_jolt/vjolt_controller_fluid.cpp
+++ b/vphysics_jolt/vjolt_controller_fluid.cpp
@@ -103,14 +103,7 @@ void JoltPhysicsFluidController::OnJoltPhysicsObjectDestroyed( JoltPhysicsObject
 	if ( pObject == m_pFluidObject )
 		m_pFluidObject = nullptr;
 
-	for ( auto it = m_ObjectsInShape.begin(); it != m_ObjectsInShape.end(); it++ )
-	{
-		if ( *it == pObject )
-		{
-			m_ObjectsInShape.erase( it );
-			break;
-		}
-	}
+	Erase( m_ObjectsInShape, pObject );
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/vphysics_jolt/vjolt_environment.h
+++ b/vphysics_jolt/vjolt_environment.h
@@ -164,6 +164,9 @@ public:
 
 	void NotifyConstraintDisabled( JoltPhysicsConstraint* pConstraint );
 
+	void AddDirtyStaticBody( const JPH::BodyID &id );
+	void RemoveDirtyStaticBody( const JPH::BodyID &id );
+
 private:
 
 	void RemoveBodyAndDeleteObject( JoltPhysicsObject* pObject );
@@ -195,6 +198,14 @@ private:
 	mutable JPH::BodyIDVector m_CachedActiveBodies;
 
 	JPH::PhysicsSystem m_PhysicsSystem;
+
+	// A vector of objects that were awake, and changed their
+	// motion type from Dynamic -> Static, so that they can be
+	// retrieved in GetActiveObjects, and have their visuals updated.
+	// If we don't do this, objects that get moved, woken, and their
+	// movement type changed to static will not get their transforms
+	// updated on the game side.
+	mutable JPH::BodyIDVector m_DirtyStaticBodies;
 
 	std::vector< JoltPhysicsObject * > m_pDeadObjects;
 	std::vector< JoltPhysicsConstraint * > m_pDeadConstraints;

--- a/vphysics_jolt/vjolt_objectpairhash.cpp
+++ b/vphysics_jolt/vjolt_objectpairhash.cpp
@@ -54,8 +54,7 @@ void JoltPhysicsObjectPairHash::RemoveObjectPair( void *pObject0, void *pObject1
 bool JoltPhysicsObjectPairHash::IsObjectPairInHash( void *pObject0, void *pObject1 )
 {
     auto pair = CreateSortedPair( pObject0, pObject1 );
-    auto &pairHashes = m_PairHashes[ GetHashArrayIndex( PointerHasher{}( pair ) ) ];
-    return pairHashes.find( pair ) != pairHashes.end();
+	return Contains( m_PairHashes[GetHashArrayIndex( PointerHasher{}( pair ) )], pair );
 }
 
 void JoltPhysicsObjectPairHash::RemoveAllPairsForObject( void *pObject0 )
@@ -72,7 +71,7 @@ void JoltPhysicsObjectPairHash::RemoveAllPairsForObject( void *pObject0 )
 
 bool JoltPhysicsObjectPairHash::IsObjectInHash( void *pObject0 )
 {
-    return m_Objects.find( pObject0 ) != m_Objects.end();
+	return Contains( m_Objects, pObject0 );
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/vphysics_jolt/vjolt_util.h
+++ b/vphysics_jolt/vjolt_util.h
@@ -375,3 +375,9 @@ constexpr void EraseIf( T &c, Pred pred )
 	auto it = std::remove_if( c.begin(), c.end(), pred );
 	c.erase( it, c.end() );
 }
+
+template< typename T, typename Value >
+constexpr bool Contains( const T &c, const Value &value )
+{
+	return c.find( value ) != c.end();
+}

--- a/vphysics_jolt/vjolt_util.h
+++ b/vphysics_jolt/vjolt_util.h
@@ -362,3 +362,16 @@ inline uint32 tzcnt( uint32 n )
 #endif
 }
 
+template< typename T, typename Value >
+constexpr void Erase( T &c, const Value &value )
+{
+	auto it = std::remove( c.begin(), c.end(), value );
+	c.erase( it, c.end() );
+}
+
+template< typename T, typename Pred >
+constexpr void EraseIf( T &c, Pred pred )
+{
+	auto it = std::remove_if( c.begin(), c.end(), pred );
+	c.erase( it, c.end() );
+}


### PR DESCRIPTION
Adds a vector of objects that were awake, and changed their
motion type from Dynamic -> Static, so that they can be
retrieved in GetActiveObjects, and have their visuals updated.

If we don't do this, objects that get moved, woken, and their
movement type changed to static will not get their transforms
updated on the game side.

Closes: #59
Closes: #63