### PR TITLE
Implement the interface PerformanceSettings

### DIFF
--- a/vphysics_jolt/vjolt_environment.h
+++ b/vphysics_jolt/vjolt_environment.h
@@ -128,6 +128,17 @@ public:
 	void GetPerformanceSettings( physics_performanceparams_t* pOutput ) const override;
 	void SetPerformanceSettings( const physics_performanceparams_t* pSettings ) override;
 
+	// physics params related
+	inline float MaxVelocity() const;
+	inline float MaxAngularVelocity() const;
+	// most likely will go unused
+	inline int MaxCollisionsPerObjectPerTimestep() const;
+	inline int MaxCollisionChecksPerTimestep() const;
+	inline float LookAheadTimeObjectsVsWorld() const;
+	inline float LookAheadTimeObjectsVsObject() const;
+	inline float MinFrictionMass() const;
+	inline float MaxFrictionMass() const;
+
 	void ReadStats( physics_stats_t* pOutput ) override;
 	void ClearStats() override;
 
@@ -225,4 +236,6 @@ private:
 	bool m_EnableConstraintNotify = false;
 
 	mutable bool m_bActiveObjectCountFirst = true;
+
+	physics_performanceparams_t m_PhysicsPerformanceParams;
 };


### PR DESCRIPTION
Hello yet again,

As per #93 I have fixed the initial issue with the interface returning incorrect values but tried to go and make it work best I could for real rather than storing useless data as a patch. I asked Jorrit from the Jolt repo what out of the parameters was possible to implement and did so (which ended up only being the velocity related parameters). There are also inline functions for each parameter just in case they're ever needed again.
