### PR TITLE
collide: Properly deconstruct JPH::Shape (CPhysCollide)

### DIFF
--- a/vphysics_jolt/vjolt_collide.cpp
+++ b/vphysics_jolt/vjolt_collide.cpp
@@ -700,7 +700,7 @@ void JoltPhysicsCollision::VCollideUnload( vcollide_t *pVCollide )
 {
 	VCollideFreeUserData( pVCollide );
 	for ( int i = 0; i < pVCollide->solidCount; i++ )
-		delete pVCollide->solids[ i ];
+		delete pVCollide->solids[ i ]->ToShape();
 
 	delete[] pVCollide->solids;
 	delete[] pVCollide->pKeyValues;

--- a/vphysics_jolt/vjolt_collide.h
+++ b/vphysics_jolt/vjolt_collide.h
@@ -12,6 +12,8 @@
 // Does not and will not contain *any* data.
 class CPhysCollide
 {
+	~CPhysCollide() = delete;
+
 public:
 	JPH::Shape* ToShape()
 	{
@@ -42,6 +44,8 @@ public:
 // Does not and will not contain *any* data.
 class CPhysConvex
 {
+	~CPhysConvex() = delete;
+
 public:
 	JPH::ConvexShape* ToConvexShape()
 	{


### PR DESCRIPTION
This change properly calls the JPH::Shape deconstructor, rather than using the mismatched dtor in CPhysCollide

Tested on 32bit MSVC with address sanitizer.

This should fix #58 