### PR TITLE
Fixed the Workflow

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -79,7 +79,10 @@ jobs:
     - name: Build GCC x86
       working-directory: ${{ matrix.source_branch }}/src
       run: |
-        ./createjoltprojects.sh
+        chmod +x createjoltprojects.sh
+        chmod +x devtools/bin/vpc_linux
+        chmod +x devtools/bin/vpc
+        ./createjoltprojects.sh 
         make -f jolt.mak -j $(nproc)
 
     - name: Upload artifacts

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -82,6 +82,7 @@ jobs:
         chmod +x createjoltprojects.sh
         chmod +x devtools/bin/vpc_linux
         chmod +x devtools/bin/vpc
+        chmod +x devtools/gendbg.sh
         ./createjoltprojects.sh 
         make -f jolt.mak -j $(nproc)
 


### PR DESCRIPTION
The file permissions are not set correctly for the gmod files and because of that the workflow fails.
I couldn't get the permission set right with git, so I just added a few lines to always set the permissions right.

[This PR](https://github.com/Joshua-Ashton/mini-source-sdk/pull/2) is also needed for the gmod workflow to succeed.