### PR TITLE
Some Issue fixes

### DIFF
--- a/install.md
+++ b/install.md
@@ -1,0 +1,20 @@
+# Installing Volt
+
+## 32bit Game
+
+1. Download the latest [release](https://github.com/Joshua-Ashton/VPhysics-Jolt/releases)
+2. Copy the contents of the zip into the game's root directory and replace all files.
+
+## 64bit Game
+
+1. Download the latest [release](https://github.com/Joshua-Ashton/VPhysics-Jolt/releases)
+2. Copy all files located in the bin folder (from the ZIP) into the bin folder the game uses.
+NOTE: The path could be `bin/win64` or `bin/linux64`
+
+## Gmod Dedicated Server
+
+1. Download the latest [release](https://github.com/Joshua-Ashton/VPhysics-Jolt/releases)
+2. Copy all files located in the bin folder (from the ZIP) into the bin folder the game uses.
+NOTE: The path normal is `bin` could be `bin/win64` or `bin/linux64` if you use the `x86-64` Branch.
+3. Remove the `vphysics_srv.dll` and rename the `vphysics.dll` to `vphysics_srv.dll`.
+NOTE: on Linux it will be `vphysics_srv.so`

--- a/install.md
+++ b/install.md
@@ -2,19 +2,19 @@
 
 ## 32bit Game
 
-1. Download the latest [release](https://github.com/Joshua-Ashton/VPhysics-Jolt/releases)
-2. Copy the contents of the zip into the game's root directory and replace all files.
+1. Download the latest [release](https://github.com/Joshua-Ashton/VPhysics-Jolt/releases)  
+2. Copy the contents of the zip into the game's root directory and replace all files.  
 
 ## 64bit Game
 
-1. Download the latest [release](https://github.com/Joshua-Ashton/VPhysics-Jolt/releases)
-2. Copy all files located in the bin folder (from the ZIP) into the bin folder the game uses.
-NOTE: The path could be `bin/win64` or `bin/linux64`
+1. Download the latest [release](https://github.com/Joshua-Ashton/VPhysics-Jolt/releases)  
+2. Copy all files located in the bin folder (from the ZIP) into the bin folder the game uses.  
+> NOTE: The path could be `bin/win64` or `bin/linux64`  
 
 ## Gmod Dedicated Server
 
-1. Download the latest [release](https://github.com/Joshua-Ashton/VPhysics-Jolt/releases)
-2. Copy all files located in the bin folder (from the ZIP) into the bin folder the game uses.
-NOTE: The path normal is `bin` could be `bin/win64` or `bin/linux64` if you use the `x86-64` Branch.
-3. Remove the `vphysics_srv.dll` and rename the `vphysics.dll` to `vphysics_srv.dll`.
-NOTE: on Linux it will be `vphysics_srv.so`
+1. Download the latest [release](https://github.com/Joshua-Ashton/VPhysics-Jolt/releases)  
+2. Copy all files located in the bin folder (from the ZIP) into the bin folder the game uses.  
+> NOTE: The path normal is `bin` could be `bin/win64` or `bin/linux64` if you use the `x86-64` Branch.  
+3. Remove the `vphysics_srv.dll` and rename the `vphysics.dll` to `vphysics_srv.dll`.  
+> NOTE: on Linux the file will be `vphysics_srv.so`  

--- a/vphysics_jolt/vjolt_collide_trace.cpp
+++ b/vphysics_jolt/vjolt_collide_trace.cpp
@@ -38,7 +38,8 @@ static ConVar vjolt_trace_debug_collidebox( "vjolt_trace_debug_collidebox", "0",
 // Slart and I have not been able to determine the root cause of this problem and have tried for a long time...
 //
 // Slart: Portal 2 probably passes in a bad winding order in the polyhedron or something, dunno if it affects Portal 1
-static ConVar vjolt_trace_portal_hack( "vjolt_trace_portal_hack", "0", FCVAR_NONE );
+// RaphaelIT7: We this needs to always be enabled because else the traces the engine uses to determent if you can unduck fail.
+// static ConVar vjolt_trace_portal_hack( "vjolt_trace_portal_hack", "0", FCVAR_NONE );
 
 //-------------------------------------------------------------------------------------------------
 //
@@ -492,8 +493,8 @@ static void CastBoxVsShape( const Ray_t &ray, uint32 contentsMask, IConvexInfo *
 	//settings.mBackFaceModeTriangles = JPH::EBackFaceMode::CollideWithBackFaces;
 	// Josh: Had to re-enable CollideWithBackFaces to allow triggers for the Portal Environment to work.
 	// Come back here if we start getting stuck on things again...
-	if ( vjolt_trace_portal_hack.GetBool() )
-		settings.mBackFaceModeConvex = JPH::EBackFaceMode::CollideWithBackFaces;
+	// if ( vjolt_trace_portal_hack.GetBool() )
+	settings.mBackFaceModeConvex = JPH::EBackFaceMode::CollideWithBackFaces;
 	//settings.mCollisionTolerance = kCollisionTolerance;
 	settings.mUseShrunkenShapeAndConvexRadius = true;
 	settings.mReturnDeepestPoint = true;

--- a/vphysics_jolt/vjolt_controller_player.cpp
+++ b/vphysics_jolt/vjolt_controller_player.cpp
@@ -157,6 +157,8 @@ bool JoltPhysicsPlayerController::WasFrozen()
 
 static void CheckCollision( JoltPhysicsObject *pObject, JPH::CollideShapeCollector &ioCollector, JPH::BodyFilter &ioFilter )
 {
+	if (!pObject->IsCollisionEnabled()) { return; } // If we have no collisions, we have nothing to check.
+
 	JPH::PhysicsSystem *pSystem = pObject->GetEnvironment()->GetPhysicsSystem();
 
 	// TODO(Josh): Make a PLAYER ONLY layer that will only collide with MOVING ONLY annd

--- a/vphysics_jolt/vjolt_environment.h
+++ b/vphysics_jolt/vjolt_environment.h
@@ -172,7 +172,7 @@ public:
 private:
 
 	void RemoveBodyAndDeleteObject( JoltPhysicsObject* pObject );
-	void DeleteDeadObjects();
+	void DeleteDeadObjects(bool delBodies = false);
 
 	template <typename T>
 	void AddPhysicsSaveRestorePointer( uintp oldPtr, T* newPtr );

--- a/vphysics_jolt/vjolt_object.cpp
+++ b/vphysics_jolt/vjolt_object.cpp
@@ -31,6 +31,7 @@ JoltPhysicsObject::JoltPhysicsObject( JPH::Body *pBody, JoltPhysicsEnvironment *
 	, m_pGameData( pParams->pGameData )
 	, m_materialIndex( Max( nMaterialIndex, 0 ) ) // Sometimes we get passed -1.
 	, m_flVolume( pParams->volume )
+	, m_pName( pParams->pName )
 {
 	// Josh:
 	// Assert that m_pGameData is the first element, some games
@@ -916,8 +917,7 @@ const CPhysCollide *JoltPhysicsObject::GetCollide() const
 
 const char *JoltPhysicsObject::GetName() const
 {
-	// Slart: Jolt used to store debug names in JPH::Body, but it was removed. So now everybody's NoName.
-	return "NoName";
+	return m_pName;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/vphysics_jolt/vjolt_object.h
+++ b/vphysics_jolt/vjolt_object.h
@@ -239,6 +239,7 @@ private:
 	// remain un-named offset by the vtable to get to this
 	// instead of calling GetGameData().
 	void *m_pGameData = nullptr;
+	const char *m_pName = "NoName";
 
 	uint16 m_gameFlags = 0;
 	uint16 m_gameIndex = 0;


### PR DESCRIPTION
[+] Added install.md to help users install Volt.
[#] Fixed some engine traces failing.
 (some traces the engine uses to determent if you can unduck failed) 
[#] Fixed CheckCollision checking collisions even if collisions are disabled(IsCollisionEnabled = false) 
[#] JoltPhysicsObject::GetName() now returns a proper name instead of "NoName" 
In Gmod If you used tostring(Entity(1):GetPhysicsObject()) it returned NoName instead of player_stand or player_crouch.
[#] Fixed a crash

Related issues:
fixes #128
fixes #164 
fixes #102
fixes #137
fixes #85
fixes #125 (Read the [install.md](https://github.com/Joshua-Ashton/VPhysics-Jolt/blob/2ee44fc1faaabc96f374c95d203f20168a74ccd0/install.md))

Over the next few days, I want to fix more issues.