### PR TITLE
Made JoltPhysicsObject::GetName() functional

### DIFF
--- a/vphysics_jolt/vjolt_object.cpp
+++ b/vphysics_jolt/vjolt_object.cpp
@@ -31,6 +31,7 @@ JoltPhysicsObject::JoltPhysicsObject( JPH::Body *pBody, JoltPhysicsEnvironment *
 	, m_pGameData( pParams->pGameData )
 	, m_materialIndex( Max( nMaterialIndex, 0 ) ) // Sometimes we get passed -1.
 	, m_flVolume( pParams->volume )
+	, m_pName( pParams->pName )
 {
 	// Josh:
 	// Assert that m_pGameData is the first element, some games
@@ -916,8 +917,7 @@ const CPhysCollide *JoltPhysicsObject::GetCollide() const
 
 const char *JoltPhysicsObject::GetName() const
 {
-	// Slart: Jolt used to store debug names in JPH::Body, but it was removed. So now everybody's NoName.
-	return "NoName";
+	return m_pName;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/vphysics_jolt/vjolt_object.h
+++ b/vphysics_jolt/vjolt_object.h
@@ -239,6 +239,7 @@ private:
 	// remain un-named offset by the vtable to get to this
 	// instead of calling GetGameData().
 	void *m_pGameData = nullptr;
+	const char *m_pName = "NoName";
 
 	uint16 m_gameFlags = 0;
 	uint16 m_gameIndex = 0;


### PR DESCRIPTION
[#] JoltPhysicsObject::GetName() now returns a proper name instead of "NoName"
In Gmod If you used tostring(Entity(1):GetPhysicsObject()) it returned NoName instead of player_stand or player_crouch.