### PR TITLE
Minor code cleanup

### DIFF
--- a/vphysics_jolt/vjolt_controller_vehicle.cpp
+++ b/vphysics_jolt/vjolt_controller_vehicle.cpp
@@ -421,10 +421,10 @@ void JoltPhysicsVehicleController::CreateWheel( JPH::VehicleConstraintSettings &
 
 	JPH::WheelSettingsWV *wheelSettings = new JPH::WheelSettingsWV;
 	wheelSettings->mPosition			= SourceToJolt::Distance( wheelPositionLocal );
-	wheelSettings->mSuspensionDirection = JPH::Vec3( 0, 0, -1 );
-	wheelSettings->mSteeringAxis		= JPH::Vec3( 0, 0, 1 );
-	wheelSettings->mWheelUp				= JPH::Vec3( 0, 0, 1 );
-	wheelSettings->mWheelForward		= JPH::Vec3( 0, 1, 0 );
+	wheelSettings->mSuspensionDirection = -VehicleUpVector;
+	wheelSettings->mSteeringAxis		= VehicleUpVector;
+	wheelSettings->mWheelUp				= VehicleUpVector;
+	wheelSettings->mWheelForward		= VehicleForwardVector;
 	wheelSettings->mAngularDamping		= axle.wheels.rotdamping;
 	// TODO(Josh): What about more than 4 wheels?
 	wheelSettings->mMaxSteerAngle		= axleIdx == 0 ? steeringAngle : 0.0f;

--- a/vphysics_jolt/vjolt_debugrender.cpp
+++ b/vphysics_jolt/vjolt_debugrender.cpp
@@ -45,7 +45,7 @@ JoltPhysicsDebugRenderer::~JoltPhysicsDebugRenderer()
 {
 }
 
-void JoltPhysicsDebugRenderer::DrawLine( JPH::Vec3Arg inFrom, JPH::Vec3Arg inTo, JPH::ColorArg inColor )
+void JoltPhysicsDebugRenderer::DrawLine( JPH::RVec3Arg inFrom, JPH::RVec3Arg inTo, JPH::ColorArg inColor )
 {
 	Vector v1 = JoltToSource::Distance( inFrom );
 	Vector v2 = JoltToSource::Distance( inTo );
@@ -57,7 +57,7 @@ void JoltPhysicsDebugRenderer::DrawLine( JPH::Vec3Arg inFrom, JPH::Vec3Arg inTo,
 #endif
 }
 
-void JoltPhysicsDebugRenderer::DrawTriangle( JPH::Vec3Arg inV1, JPH::Vec3Arg inV2, JPH::Vec3Arg inV3, JPH::ColorArg inColor, ECastShadow inCastShadow )
+void JoltPhysicsDebugRenderer::DrawTriangle( JPH::RVec3Arg inV1, JPH::RVec3Arg inV2, JPH::RVec3Arg inV3, JPH::ColorArg inColor, ECastShadow inCastShadow )
 {
 	//DrawTriangle_Internal( JPH::Float3( inV1.GetX(), inV1.GetY(), inV1.GetZ() ), JPH::Float3( inV2.GetX(), inV2.GetY(), inV2.GetZ() ), JPH::Float3( inV3.GetX(), inV3.GetY(), inV3.GetZ() ), inColor );
 }
@@ -176,7 +176,7 @@ void JoltPhysicsDebugRenderer::DrawGeometry( JPH::Mat44Arg inModelMatrix, const 
 #endif
 }
 
-void JoltPhysicsDebugRenderer::DrawText3D( JPH::Vec3Arg inPosition, const std::string_view &inString, JPH::ColorArg inColor, float inHeight )
+void JoltPhysicsDebugRenderer::DrawText3D( JPH::RVec3Arg inPosition, const std::string_view &inString, JPH::ColorArg inColor, float inHeight )
 {
 	// Josh:
 	// Doing a copy of 1024, the max size allowed by a debug overlay

--- a/vphysics_jolt/vjolt_debugrender.h
+++ b/vphysics_jolt/vjolt_debugrender.h
@@ -15,9 +15,9 @@ public:
 	// JPH::DebugRenderer + Draw Implementation
 	///////////////////////////////////////////
 
-	void DrawLine( JPH::Vec3Arg inFrom, JPH::Vec3Arg inTo, JPH::ColorArg inColor ) override;
+	void DrawLine( JPH::RVec3Arg inFrom, JPH::RVec3Arg inTo, JPH::ColorArg inColor ) override;
 
-	void DrawTriangle( JPH::Vec3Arg inV1, JPH::Vec3Arg inV2, JPH::Vec3Arg inV3, JPH::ColorArg inColor, ECastShadow inCastShadow = ECastShadow::Off ) override;
+	void DrawTriangle( JPH::RVec3Arg inV1, JPH::RVec3Arg inV2, JPH::RVec3Arg inV3, JPH::ColorArg inColor, ECastShadow inCastShadow = ECastShadow::Off ) override;
 
 	Batch CreateTriangleBatch( const Triangle *inTriangles, int inTriangleCount ) override;
 	Batch CreateTriangleBatch( const Vertex *inVertices, int inVertexCount, const uint32 *inIndices, int inIndexCount ) override;
@@ -25,7 +25,7 @@ public:
 	// This parameter list sucks
 	void DrawGeometry( JPH::Mat44Arg inModelMatrix, const JPH::AABox &inWorldSpaceBounds, float inLODScaleSq, JPH::ColorArg inModelColor, const GeometryRef &inGeometry, ECullMode inCullMode = ECullMode::CullBackFace, ECastShadow inCastShadow = ECastShadow::On, EDrawMode inDrawMode = EDrawMode::Solid ) override;
 
-	void DrawText3D( JPH::Vec3Arg inPosition, const std::string_view &inString, JPH::ColorArg inColor = JPH::Color::sWhite, float inHeight = 0.5f ) override;
+	void DrawText3D( JPH::RVec3Arg inPosition, const std::string_view &inString, JPH::ColorArg inColor = JPH::Color::sWhite, float inHeight = 0.5f ) override;
 
 	///////////////////////////////////////////
 	// Hehe


### PR DESCRIPTION
debugrenderer's arguments were not matching base class (although the underlying type is the same), and vehicle suspension settings were not using already defined up and forward constants and instead were constructing them in-place