### PR TITLE
collision_query: Fixed incorrect triangles position

### DIFF
--- a/vphysics_jolt/vjolt_querymodel.cpp
+++ b/vphysics_jolt/vjolt_querymodel.cpp
@@ -61,9 +61,9 @@ void JoltCollisionQuery::GetTriangleVerts( int convexIndex, int triangleIndex, V
 
 			if ( triangleIndex >= i && triangleIndex < i + count )
 			{
-				verts[ 0 ] = JoltToSource::Distance( vertices[ ( triangleIndex % kRequestedTriangles ) * 3 + 0 ] );
-				verts[ 1 ] = JoltToSource::Distance( vertices[ ( triangleIndex % kRequestedTriangles ) * 3 + 1 ] );
-				verts[ 2 ] = JoltToSource::Distance( vertices[ ( triangleIndex % kRequestedTriangles ) * 3 + 2 ] );
+				verts[ 0 ] = JoltToSource::Distance( vertices[ ( triangleIndex % kRequestedTriangles ) * 3 + 0 ] ) + JoltToSource::Distance( pShape->GetCenterOfMass() );
+				verts[ 1 ] = JoltToSource::Distance( vertices[ ( triangleIndex % kRequestedTriangles ) * 3 + 1 ] ) + JoltToSource::Distance( pShape->GetCenterOfMass() );
+				verts[ 2 ] = JoltToSource::Distance( vertices[ ( triangleIndex % kRequestedTriangles ) * 3 + 2 ] ) + JoltToSource::Distance( pShape->GetCenterOfMass() );
 				return 0;
 			}
 


### PR DESCRIPTION
For scaling physics props, Source gets all the vertices from collision model, scales their position (as it's relative to object, it's a matter of just `position *= scale`) and constructs a brand new collide out of that. However, Jolt (or Volt) appears to move model's origin to the center, and then offset it back to original pose by applying custom center of mass, which results in those rebuilt vertices having incorrect position (scaled from the center of the mesh, rather than it's origin). Applying center of mesh position manually to each vertex fixes the issue.