### PR TITLE
Fix collision with moving triggers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 # This file is here so GitHub uses 4-space tabs...
 
-root = true
+root = false
 
 [*]
 indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ generated_code_*
 *.ixx.ifc.dt.module.json.command
 *.ixx.ifc.dt.module.json
 *.ixx.ifc.dt.d.json
+*.obj.d.json
+*.obj.dt.module.json
+*.obj.dt.d.json
+*.obj.dt.module.json.command
 
 
 # Linux Stuff

--- a/vphysics_jolt/compat/branch_overrides.h
+++ b/vphysics_jolt/compat/branch_overrides.h
@@ -19,6 +19,14 @@
 #define override_not_gmod override
 #endif
 
+#if defined( GAME_VITAMIN )
+#define override_vitamin override
+#define override_not_vitamin
+#else
+#define override_vitamin
+#define override_not_vitamin override
+#endif
+
 #if defined( GAME_CSGO ) || defined( GAME_VITAMIN ) || defined( GAME_PORTAL2 )
 #define GAME_PORTAL2_OR_NEWER
 #define override_portal2 override

--- a/vphysics_jolt/vjolt_collide.cpp
+++ b/vphysics_jolt/vjolt_collide.cpp
@@ -736,6 +736,71 @@ public:
 
 //-------------------------------------------------------------------------------------------------
 
+static CPhysCollide *DeserializeCollide( const char *pData, int size, int index )
+{
+	const ivp_compat::collideheader_t *pCollideHeader = reinterpret_cast<const ivp_compat::collideheader_t *>( pData );
+
+	if ( pCollideHeader->vphysicsID == ivp_compat::VPHYSICS_COLLISION_ID )
+	{
+		// This is the main path that everything falls down for a modern
+		// .phy file with the collide header.
+
+		if ( pCollideHeader->version != ivp_compat::VPHYSICS_COLLISION_VERSION )
+			Log_Warning( LOG_VJolt, "Solid with unknown version: 0x%x, may crash!\n", pCollideHeader->version );
+
+		switch ( pCollideHeader->modelType )
+		{
+			case ivp_compat::COLLIDE_POLY:
+				return DeserializeIVP_Poly( pCollideHeader );
+
+			case COLLIDE_JOLT:
+				return JoltCollideData::Deserialize( pCollideHeader );
+
+			case ivp_compat::COLLIDE_MOPP:
+				Log_Warning( LOG_VJolt, "Unsupported solid type COLLIDE_MOPP on solid %d. Skipping...\n", index );
+				break;
+	
+			case ivp_compat::COLLIDE_BALL:
+				Log_Warning( LOG_VJolt, "Unsupported solid type COLLIDE_BALL on solid %d. Skipping...\n", index );
+				break;
+
+			case ivp_compat::COLLIDE_VIRTUAL:
+				Log_Warning( LOG_VJolt, "Unsupported solid type COLLIDE_VIRTUAL on solid %d. Skipping...\n", index );
+				break;
+
+			default:
+				Log_Warning( LOG_VJolt, "Unsupported solid type 0x%x on solid %d. Skipping...\n", (int)pCollideHeader->modelType, index );
+				break;
+		}
+	}
+	else
+	{
+		// This must be a legacy style .phy where it is just a dumped compact surface.
+		// Some props in shipping HL2 still use this format, as they have a .phy, even after their
+		// .qc had the $collisionmodel removed, as they didn't get the stale .phy in the game files deleted.
+
+		const ivp_compat::compactsurface_t *pCompactSurface = reinterpret_cast<const ivp_compat::compactsurface_t *>( pData );
+		const int legacyModelType = pCompactSurface->dummy[2];
+		switch ( legacyModelType )
+		{
+			case ivp_compat::IVP_COMPACT_SURFACE_SUPER_LEGACY:
+			case ivp_compat::IVP_COMPACT_SURFACE_ID:
+			case ivp_compat::IVP_COMPACT_SURFACE_ID_SWAPPED:
+				return DeserializeIVP_Poly( pCompactSurface );
+
+			case ivp_compat::IVP_COMPACT_MOPP_ID:
+				Log_Warning( LOG_VJolt, "Unsupported legacy solid type IVP_COMPACT_MOPP_ID on solid %d. Skipping...\n", index );
+				break;
+
+			default:
+				Log_Warning( LOG_VJolt, "Unsupported legacy solid type 0x%x on solid %d. Skipping...\n", legacyModelType, index );
+				break;
+		}
+	}
+
+	return nullptr;
+}
+
 void JoltPhysicsCollision::VCollideLoad( vcollide_t *pOutput, int solidCount, const char *pBuffer, int size, bool swap /*= false*/ )
 {
 	if ( swap )
@@ -757,68 +822,7 @@ void JoltPhysicsCollision::VCollideLoad( vcollide_t *pOutput, int solidCount, co
 		const int solidSize = *reinterpret_cast<const int *>( pCursor );
 		pCursor += sizeof( int );
 
-		const ivp_compat::collideheader_t *pCollideHeader = reinterpret_cast<const ivp_compat::collideheader_t *>( pCursor );
-
-		if ( pCollideHeader->vphysicsID == ivp_compat::VPHYSICS_COLLISION_ID )
-		{
-			// This is the main path that everything falls down for a modern
-			// .phy file with the collide header.
-
-			if ( pCollideHeader->version != ivp_compat::VPHYSICS_COLLISION_VERSION )
-				Log_Warning( LOG_VJolt, "Solid with unknown version: 0x%x, may crash!\n", pCollideHeader->version );
-
-			switch ( pCollideHeader->modelType )
-			{
-				case ivp_compat::COLLIDE_POLY:
-					pOutput->solids[ i ] = DeserializeIVP_Poly( pCollideHeader );
-					break;
-
-				case COLLIDE_JOLT:
-					pOutput->solids[i] = JoltCollideData::Deserialize( pCollideHeader );
-					break;
-
-				case ivp_compat::COLLIDE_MOPP:
-					Log_Warning( LOG_VJolt, "Unsupported solid type COLLIDE_MOPP on solid %d. Skipping...\n", i );
-					break;
-	
-				case ivp_compat::COLLIDE_BALL:
-					Log_Warning( LOG_VJolt, "Unsupported solid type COLLIDE_BALL on solid %d. Skipping...\n", i );
-					break;
-
-				case ivp_compat::COLLIDE_VIRTUAL:
-					Log_Warning( LOG_VJolt, "Unsupported solid type COLLIDE_VIRTUAL on solid %d. Skipping...\n", i );
-					break;
-
-				default:
-					Log_Warning( LOG_VJolt, "Unsupported solid type 0x%x on solid %d. Skipping...\n", (int)pCollideHeader->modelType, i );
-					break;
-			}
-		}
-		else
-		{
-			// This must be a legacy style .phy where it is just a dumped compact surface.
-			// Some props in shipping HL2 still use this format, as they have a .phy, even after their
-			// .qc had the $collisionmodel removed, as they didn't get the stale .phy in the game files deleted.
-
-			const ivp_compat::compactsurface_t *pCompactSurface = reinterpret_cast<const ivp_compat::compactsurface_t *>( pCursor );
-			const int legacyModelType = pCompactSurface->dummy[2];
-			switch ( legacyModelType )
-			{
-				case ivp_compat::IVP_COMPACT_SURFACE_SUPER_LEGACY:
-				case ivp_compat::IVP_COMPACT_SURFACE_ID:
-				case ivp_compat::IVP_COMPACT_SURFACE_ID_SWAPPED:
-					pOutput->solids[i] = DeserializeIVP_Poly( pCompactSurface );
-					break;
-
-				case ivp_compat::IVP_COMPACT_MOPP_ID:
-					Log_Warning( LOG_VJolt, "Unsupported legacy solid type IVP_COMPACT_MOPP_ID on solid %d. Skipping...\n", i );
-					break;
-
-				default:
-					Log_Warning( LOG_VJolt, "Unsupported legacy solid type 0x%x on solid %d. Skipping...\n", legacyModelType, i);
-					break;
-			}
-		}
+		pOutput->solids[ i ] = DeserializeCollide( pCursor, solidSize, i );
 
 		pCursor += solidSize;
 	}
@@ -875,8 +879,7 @@ int JoltPhysicsCollision::CollideWrite( char *pDest, CPhysCollide *pCollide, boo
 
 CPhysCollide *JoltPhysicsCollision::UnserializeCollide( char *pBuffer, int size, int index )
 {
-	Log_Stub( LOG_VJolt );
-	return nullptr;
+	return DeserializeCollide( pBuffer, size, index );
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/vphysics_jolt/vjolt_collide.cpp
+++ b/vphysics_jolt/vjolt_collide.cpp
@@ -6,6 +6,7 @@
 
 #include "vjolt_parse.h"
 #include "vjolt_querymodel.h"
+#include "vjolt_environment.h"
 
 #include "vjolt_collide.h"
 
@@ -194,26 +195,6 @@ void JoltPhysicsCollision::DestroyCollide( CPhysCollide *pCollide )
 		return;
 
 	pCollide->ToShape()->Release();
-}
-
-//-------------------------------------------------------------------------------------------------
-
-int JoltPhysicsCollision::CollideSize( CPhysCollide *pCollide )
-{
-	Log_Stub( LOG_VJolt );
-	return 0;
-}
-
-int JoltPhysicsCollision::CollideWrite( char *pDest, CPhysCollide *pCollide, bool bSwap /*= false*/ )
-{
-	Log_Stub( LOG_VJolt );
-	return 0;
-}
-
-CPhysCollide *JoltPhysicsCollision::UnserializeCollide( char *pBuffer, int size, int index )
-{
-	Log_Stub( LOG_VJolt );
-	return nullptr;
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -605,6 +586,156 @@ namespace ivp_compat
 	}
 }
 
+//-------------------------------------------------------------------------------------------------
+
+// StreamOut implementation that counts the size required to save the data
+class JoltStreamOutSize final : public JPH::StreamOut
+{
+public:
+	void WriteBytes( const void *inData, size_t inNumBytes ) { m_nSize += inNumBytes; }
+	bool IsFailed() const override { return false; }
+	size_t GetSize() const { return m_nSize; }
+private:
+	size_t m_nSize = 0;
+};
+
+// StreamOut implementation that writes to a pointer
+class JoltPointerStreamOut final : public JPH::StreamOut
+{
+public:
+	JoltPointerStreamOut( void *pDest )
+		: m_pStart( static_cast<byte*>( pDest ) )
+		, m_pData( m_pStart )
+	{
+		VJoltAssert( pDest != nullptr );
+	}
+
+	void WriteBytes( const void *inData, size_t inNumBytes ) override
+	{
+		V_memcpy( m_pData, inData, inNumBytes );
+		m_pData += inNumBytes;
+	}
+
+	bool IsFailed() const override { return false; }
+	size_t GetSize() const { return m_pData - m_pStart; }
+
+private:
+	byte *m_pStart;
+	byte *m_pData;
+};
+
+// StreamIn implementation that reads from a pointer
+class JoltPointerStreamIn final : public JPH::StreamIn
+{
+public:
+	JoltPointerStreamIn( const void *pDest )
+		: m_pStart( static_cast<const byte*>( pDest ) )
+		, m_pData( m_pStart )
+	{
+		VJoltAssert( pDest != nullptr );
+	}
+
+	void ReadBytes( void *outData, size_t inNumBytes )
+	{
+		V_memcpy( outData, m_pData, inNumBytes );
+		m_pData += inNumBytes;
+	}
+
+	bool IsEOF() const override { return false; }
+	bool IsFailed() const override { return false; }
+	size_t GetSize() const { return m_pData - m_pStart; }
+
+private:
+	const byte *m_pStart;
+	const byte *m_pData;
+};
+
+//-------------------------------------------------------------------------------------------------
+
+static constexpr int32	VJOLT_COLLISION_ID		= MAKEID('J','O','L','T');
+static constexpr int32	VJOLT_COLLISION_VERSION	= 0x1'00'00;
+enum
+{
+	COLLIDE_JOLT = 'J' | ( u'P' << 8 )
+};
+
+class JoltCollideData
+{
+private:
+	ivp_compat::collideheader_t header = {
+		.vphysicsID	= ivp_compat::VPHYSICS_COLLISION_ID,
+		.version	= ivp_compat::VPHYSICS_COLLISION_VERSION,
+		.modelType	= COLLIDE_JOLT,
+	};
+	int32 joltCollisionID		= VJOLT_COLLISION_ID;
+	int32 joltCollisionVersion	= VJOLT_COLLISION_VERSION;
+	int64 joltVersion			= JPH_VERSION_ID;
+	uint64 collideSize			= 0;
+
+public:
+	static CPhysCollide *Deserialize( const ivp_compat::collideheader_t *pCollideHeader )
+	{
+		const JoltCollideData *pHeader = reinterpret_cast<const JoltCollideData*>( pCollideHeader );
+
+		if ( pHeader->joltCollisionID != VJOLT_COLLISION_ID )
+		{
+			Log_Warning( LOG_VJolt, "Jolt collider with invalid ID!\n", pHeader->joltVersion );
+			return nullptr;
+		}
+
+		if ( pHeader->joltCollisionVersion != VJOLT_COLLISION_VERSION )
+			Log_Warning( LOG_VJolt, "Jolt collider with unknown collide version: 0x%x, may crash!\n", pHeader->joltVersion );
+
+		if ( byte majorVersion = pHeader->joltVersion >> 16; majorVersion != JPH_VERSION_MAJOR )
+		{
+			static_assert( JPH_VERSION_MAJOR == 5, "Jolt major version changed, make sure that PHY files can still be loaded!" );
+			VJoltAssert( 0 );
+			Log_Warning( LOG_VJolt, "Jolt collider saved from Jolt version %d, expected version %d!\n", int( majorVersion ), JPH_VERSION_MAJOR );
+		}
+
+		JoltPointerStreamIn stream( pHeader + 1 );
+		JPH::Shape::IDToShapeMap idToShape;
+		JPH::Shape::IDToMaterialMap idToMaterial;
+		JPH::Shape::ShapeResult pShape = JPH::Shape::sRestoreWithChildren( stream, idToShape, idToMaterial );
+
+		Assert( stream.GetSize() == pHeader->collideSize );
+
+		return CPhysCollide::FromShape( ToDanglingRef( pShape.Get() ) );
+	}
+
+	static size_t ComputeSize( CPhysCollide *pCollide )
+	{
+		JoltStreamOutSize sizer;
+		JPH::Shape::ShapeToIDMap ioShapeMap;
+		JPH::Shape::MaterialToIDMap ioMaterialMap;
+		pCollide->ToShape()->SaveWithChildren( sizer, ioShapeMap, ioMaterialMap );
+
+		return sizeof( JoltCollideData ) + sizer.GetSize();
+	}
+
+	static size_t Serialize( byte *pDest, CPhysCollide *pCollide )
+	{
+		// Write header
+		JoltCollideData* pCollideData = reinterpret_cast<JoltCollideData *>( pDest );
+		*pCollideData = JoltCollideData();
+		pDest += sizeof( JoltCollideData );
+
+		// Write collide
+		JoltPointerStreamOut stream( pDest );
+		JPH::Shape::ShapeToIDMap ioShapeMap;
+		JPH::Shape::MaterialToIDMap ioMaterialMap;
+		pCollide->ToShape()->SaveWithChildren( stream, ioShapeMap, ioMaterialMap );
+
+		// Write size
+		size_t size = stream.GetSize();
+		pCollideData->collideSize = size;
+
+		return sizeof( JoltCollideData ) + size;
+	}
+};
+
+//-------------------------------------------------------------------------------------------------
+
 void JoltPhysicsCollision::VCollideLoad( vcollide_t *pOutput, int solidCount, const char *pBuffer, int size, bool swap /*= false*/ )
 {
 	if ( swap )
@@ -640,6 +771,10 @@ void JoltPhysicsCollision::VCollideLoad( vcollide_t *pOutput, int solidCount, co
 			{
 				case ivp_compat::COLLIDE_POLY:
 					pOutput->solids[ i ] = DeserializeIVP_Poly( pCollideHeader );
+					break;
+
+				case COLLIDE_JOLT:
+					pOutput->solids[i] = JoltCollideData::Deserialize( pCollideHeader );
 					break;
 
 				case ivp_compat::COLLIDE_MOPP:
@@ -712,6 +847,36 @@ void JoltPhysicsCollision::VCollideUnload( vcollide_t *pVCollide )
 	delete[] pVCollide->solids;
 	delete[] pVCollide->pKeyValues;
 	V_memset( pVCollide, 0, sizeof( *pVCollide ) );
+}
+
+//-------------------------------------------------------------------------------------------------
+
+int JoltPhysicsCollision::CollideSize( CPhysCollide *pCollide )
+{
+	if ( !pCollide )
+		return 0;
+
+	return static_cast<int>( JoltCollideData::ComputeSize( pCollide ) );
+}
+
+int JoltPhysicsCollision::CollideWrite( char *pDest, CPhysCollide *pCollide, bool bSwap /*= false*/ )
+{
+	if ( !pCollide )
+		return 0;
+
+	if ( bSwap )
+	{
+		Log_Error( LOG_VJolt, "If you got here. Tell me what you did!\n" );
+		return 0;
+	}
+
+	return static_cast<int>( JoltCollideData::Serialize( reinterpret_cast<byte *>( pDest ), pCollide ) );
+}
+
+CPhysCollide *JoltPhysicsCollision::UnserializeCollide( char *pBuffer, int size, int index )
+{
+	Log_Stub( LOG_VJolt );
+	return nullptr;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/vphysics_jolt/vjolt_collide.cpp
+++ b/vphysics_jolt/vjolt_collide.cpp
@@ -956,6 +956,45 @@ void JoltPhysicsCollision::DuplicateAndScale( vcollide_t *pOut, const vcollide_t
 
 //-------------------------------------------------------------------------------------------------
 
+bool JoltPhysicsCollision::SupportsCreateCollide2()
+{
+	return true;
+}
+
+CPhysCollide* JoltPhysicsCollision::CreateCollide2( CPhysConvex **pConvex, int convexCount, CPhysPolysoup **pPolysoups, int polysoupCount, const convertconvexparams_t &convertParams )
+{
+	// If we only have one shape, we can just use that directly,
+	// without making a compound shape.
+	if ( convexCount == 1 && polysoupCount == 0 )
+		return pConvex[0]->ToPhysCollide();
+
+	if ( polysoupCount == 1 && convexCount == 0 )
+		return ConvertPolysoupToCollide( pPolysoups[0], false );
+
+	JPH::StaticCompoundShapeSettings settings;
+
+	for ( int i = 0; i < convexCount; i++ )
+	{
+		settings.AddShape( JPH::Vec3::sZero(), JPH::Quat::sIdentity(), pConvex[i]->ToConvexShape() );
+	}
+
+	for ( int i = 0; i < polysoupCount; i++ )
+	{
+		// Convert polysoups to mesh colliders
+		JPH::MeshShapeSettings meshShapeSettings( pPolysoups[i]->Triangles );
+		JPH::Shape::ShapeResult meshShape = meshShapeSettings.Create();
+
+		if ( !meshShape.IsValid() )
+			continue;
+
+		settings.AddShape( JPH::Vec3::sZero(), JPH::Quat::sIdentity(), meshShape.Get() );
+	}
+
+	return ShapeSettingsToPhysCollide( settings );
+}
+
+//-------------------------------------------------------------------------------------------------
+
 const JPH::Shape *CreateCOMOverrideShape( const JPH::Shape* pShape, JPH::Vec3Arg comOverride )
 {
 	JPH::Vec3 comOffset = comOverride - pShape->GetCenterOfMass();

--- a/vphysics_jolt/vjolt_collide.h
+++ b/vphysics_jolt/vjolt_collide.h
@@ -183,6 +183,9 @@ public:
 
 	void			DuplicateAndScale( vcollide_t *pOut, const vcollide_t *pIn, float flScale ) override_csgo;
 
+	bool			SupportsCreateCollide2() override_vitamin;
+	CPhysCollide*	CreateCollide2( CPhysConvex **pConvex, int nConvexCount, CPhysPolysoup **ppPolysoups, int nPolySoups, const convertconvexparams_t &convertParams ) override_vitamin;
+
 public:
 	static JoltPhysicsCollision& GetInstance() { return s_PhysicsCollision; }
 

--- a/vphysics_jolt/vjolt_collide_trace.cpp
+++ b/vphysics_jolt/vjolt_collide_trace.cpp
@@ -213,9 +213,14 @@ public:
 		// Ensure that the contents filter was used
 		VJoltAssert( contents & m_ContentsMask );
 
-#if 0
-		// Test if this collision is closer than the previous one
 		const float theirEarlyOut = inResult.GetEarlyOutFraction();
+		if ( theirEarlyOut < 0.0f )
+			m_bStartSolid = true;
+
+		if ( inResult.mPenetrationAxis.Dot( m_vDisplacement ) <= 0.0f ) // Ignore penetrations that we're moving away from
+			return;
+
+		// Test if this collision is closer than the previous one
 		const float ourEarlyOut = GetEarlyOutFraction();
 		if ( !m_DidHit || theirEarlyOut < ourEarlyOut )
 		{
@@ -231,35 +236,9 @@ public:
 
 			m_DidHit = true;
 			m_HitBackFace = inResult.mIsBackFaceHit;
-		}
-#endif
 
-		const float theirEarlyOut = inResult.GetEarlyOutFraction();
-		if ( theirEarlyOut < 0.0f )
-			m_bStartSolid = true;
-
-		if ( inResult.mPenetrationAxis.Dot( m_vDisplacement ) > 0.0f ) // Ignore penetrations that we're moving away from
-		{
-			// Test if this collision is closer than the previous one
-			const float ourEarlyOut = GetEarlyOutFraction();
-			if ( !m_DidHit || theirEarlyOut < ourEarlyOut )
-			{
-				// Update our early out fraction
-				UpdateEarlyOutFraction( theirEarlyOut );
-
-				m_Fraction = inResult.mFraction;
-				m_ResultContents = contents;
-				m_SubShapeID = inResult.mSubShapeID2;
-				m_ContactPoint = inResult.mContactPointOn2;
-				m_PenetrationAxis = inResult.mPenetrationAxis;
-				m_PenetrationDepth = inResult.mPenetrationDepth;
-
-				m_DidHit = true;
-				m_HitBackFace = inResult.mIsBackFaceHit;
-
-				if ( ourEarlyOut < 0.0f )
-					m_bEndSolid = true;
-			}
+			if ( ourEarlyOut < 0.0f )
+				m_bEndSolid = true;
 		}
 	}
 

--- a/vphysics_jolt/vjolt_interface.h
+++ b/vphysics_jolt/vjolt_interface.h
@@ -34,7 +34,7 @@ using IVJoltDebugOverlay = IVDebugOverlay;
 #endif
 
 // So we can toggle assertions in this module at our discretion
-#if DEVELOPMENT_ONLY
+#if 0 // DEVELOPMENT_ONLY
 #define VJoltAssert	DevAssert
 #define VJoltAssertMsg DevAssertMsg
 #else

--- a/vphysics_wrapper/vphysics_wrapper.cpp
+++ b/vphysics_wrapper/vphysics_wrapper.cpp
@@ -25,6 +25,8 @@
 class PhysicsWrapper final : public CBaseAppSystem<IPhysics>
 {
 public:
+	PhysicsWrapper();
+
 	bool Connect( CreateInterfaceFn factory ) override;
 	void Disconnect() override;
 
@@ -45,6 +47,8 @@ public:
 
 public:
 	static PhysicsWrapper &GetInstance() { return s_PhysicsInterface; }
+	static IPhysicsCollision &GetPhysicsCollision() { return *s_pPhysicsCollision; }
+	static IPhysicsSurfaceProps &GetPhysicsSurfaceProps() { return *s_pPhysicsSurfaceProps; }
 
 private:
 	bool InitWrapper();
@@ -53,10 +57,18 @@ private:
 	IPhysics *m_pActualPhysicsInterface;
 
 	static PhysicsWrapper s_PhysicsInterface;
+	static IPhysicsCollision *s_pPhysicsCollision;
+	static IPhysicsSurfaceProps *s_pPhysicsSurfaceProps;
 };
 
 PhysicsWrapper PhysicsWrapper::s_PhysicsInterface;
 EXPOSE_SINGLE_INTERFACE_GLOBALVAR( PhysicsWrapper, IPhysics, VPHYSICS_INTERFACE_VERSION, PhysicsWrapper::GetInstance() );
+
+IPhysicsCollision *PhysicsWrapper::s_pPhysicsCollision = nullptr;
+EXPOSE_SINGLE_INTERFACE_GLOBALVAR( JoltPhysicsCollision, IPhysicsCollision, VPHYSICS_COLLISION_INTERFACE_VERSION, PhysicsWrapper::GetPhysicsCollision() );
+
+IPhysicsSurfaceProps *PhysicsWrapper::s_pPhysicsSurfaceProps = nullptr;
+EXPOSE_SINGLE_INTERFACE_GLOBALVAR( JoltPhysicsSurfaceProps, IPhysicsSurfaceProps, VPHYSICS_SURFACEPROPS_INTERFACE_VERSION, PhysicsWrapper::GetPhysicsSurfaceProps() );
 
 //-------------------------------------------------------------------------------------------------
 
@@ -122,7 +134,25 @@ bool PhysicsWrapper::InitWrapper()
 	if ( !Sys_LoadInterface( pModuleName, VPHYSICS_INTERFACE_VERSION, &m_pActualPhysicsModule, (void **)&m_pActualPhysicsInterface ) )
 		return false;
 
+	if ( m_pActualPhysicsModule )
+	{
+		// Get all the other interfaces
+		CreateInterfaceFn factory = Sys_GetFactory( m_pActualPhysicsModule );
+		if ( factory )
+		{
+			s_pPhysicsCollision = static_cast<IPhysicsCollision *>( factory( VPHYSICS_COLLISION_INTERFACE_VERSION, nullptr ) );
+			s_pPhysicsSurfaceProps = static_cast<IPhysicsSurfaceProps *>( factory( VPHYSICS_SURFACEPROPS_INTERFACE_VERSION, nullptr ) );
+		}
+	}
+
 	return true;
+}
+
+PhysicsWrapper::PhysicsWrapper()
+{
+	// Load the actual module immediately so our
+	// CreateInterface can return all interfaces from it
+	InitWrapper();
 }
 
 bool PhysicsWrapper::Connect( CreateInterfaceFn factory )


### PR DESCRIPTION
Fixes collision with moving triggers without compromising the stuck robustness of polysoups.

Might also fix #128 