### PR TITLE
Bring public 64x support for GMod

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -7,7 +7,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        source_branch: [sdk2013-sp, sdk2013-mp, asw, gmod]
+        name: [sdk2013-sp, sdk2013-mp, asw, gmod, gmod_64]
+        include:
+          - name: sdk2013-sp
+            branch: sdk2013-sp
+            arch: '32'
+            vscodeArch: 'x86'
+          - name: sdk2013-mp
+            branch: sdk2013-mp
+            arch: '32'
+            vscodeArch: 'x86'
+          - name: asw
+            branch: asw
+            arch: '32'
+            vscodeArch: 'x86'
+          - name: gmod
+            branch: gmod
+            arch: '32'
+            vscodeArch: 'x86'
+          - name: gmod_64
+            branch: gmod
+            arch: '64'
+            vscodeArch: 'x64'
 
     runs-on: windows-2022
 
@@ -20,7 +41,7 @@ jobs:
     - name: Checkout VPhysics Jolt
       uses: actions/checkout@v3
       with:
-        path: ${{ matrix.source_branch }}/src/vphysics_jolt
+        path: ${{ matrix.branch }}/src/vphysics_jolt
         submodules: recursive
 
     - name: Find Visual Studio
@@ -32,28 +53,41 @@ jobs:
           | Out-File -FilePath "${Env:GITHUB_ENV}" -Append
 
     - name: Build MSVC x86
-      working-directory: ${{ matrix.source_branch }}/src
+      working-directory: ${{ matrix.branch }}/src
       run: |
         & "${Env:COMSPEC}" /s /c "`"${Env:VSDEVCMD}`" -arch=x86 -host_arch=x64 -no_logo && set" `
           | % { , ($_ -Split '=', 2) } `
           | % { [System.Environment]::SetEnvironmentVariable($_[0], $_[1]) }
         .\fix_registry.bat
-        .\createjoltprojects.bat
+        .\createjoltprojects.bat ${{ matrix.arch }}
         devenv jolt.sln /upgrade
-        msbuild jolt.sln /nodeReuse:false /t:Rebuild /p:Configuration=Release /p:Platform=x86 /m /v:minimal
+        msbuild jolt.sln /nodeReuse:false /t:Rebuild /p:Configuration=Release /p:Platform=${{ matrix.vscodeArch }} /m /v:minimal
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: vphysics_jolt_${{ matrix.source_branch }}_win32
-        path: ${{ matrix.source_branch }}/game
+        name: vphysics_jolt_${{ matrix.branch }}_win${{ matrix.arch }}
+        path: ${{ matrix.branch }}/game
         if-no-files-found: error
 
   linux:
     strategy:
       fail-fast: false
       matrix:
-        source_branch: [sdk2013-sp, sdk2013-mp, gmod]
+        name: [sdk2013-sp, sdk2013-mp, gmod, gmod_64]
+        include:
+          - name: sdk2013-sp
+            branch: sdk2013-sp
+            arch: '32'
+          - name: sdk2013-mp
+            branch: sdk2013-mp
+            arch: '32'
+          - name: gmod
+            branch: gmod
+            arch: '32'
+          - name: gmod_64
+            branch: gmod
+            arch: '64'
 
     runs-on: ubuntu-latest
     container: debian:bullseye
@@ -73,22 +107,25 @@ jobs:
     - name: Checkout VPhysics Jolt
       uses: actions/checkout@v3
       with:
-        path: ${{ matrix.source_branch }}/src/vphysics_jolt
+        path: ${{ matrix.branch }}/src/vphysics_jolt
         submodules: recursive
 
     - name: Build GCC x86
-      working-directory: ${{ matrix.source_branch }}/src
+      working-directory: ${{ matrix.branch }}/src
       run: |
         chmod +x createjoltprojects.sh
         chmod +x devtools/bin/vpc_linux
         chmod +x devtools/bin/vpc
         chmod +x devtools/gendbg.sh
-        ./createjoltprojects.sh 
-        make -f jolt.mak -j $(nproc)
+        ./createjoltprojects.sh ${{ matrix.arch }}
+        if [ "${{ matrix.arch }}" = "64" ]; then
+          make -f jolt.mak ARCH_FLAGS="-march=x86-64 -mtune=generic" -j $(nproc)
+        else
+          make -f jolt.mak -j $(nproc)
+        fi
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: vphysics_jolt_${{ matrix.source_branch }}_linux32
-        path: ${{ matrix.source_branch }}/game
-        if-no-files-found: error
+        name: vphysics_jolt_${{ matrix.branch }}_linux${{ matrix.arch }}
+        path: ${{ matrix.branch }}/game

--- a/vphysics_jolt/compat/branch_overrides.h
+++ b/vphysics_jolt/compat/branch_overrides.h
@@ -1,7 +1,19 @@
 
 #pragma once
 
-#if defined( GAME_CSGO ) || defined( GAME_VITAMIN )
+// GMod SDK2013 x86 branch
+#if defined( GAME_GMOD )
+#if PLATFORM_64BITS
+#define GAME_GMOD_64X
+#endif
+#define override_gmod override
+#define override_not_gmod
+#else
+#define override_gmod
+#define override_not_gmod override
+#endif
+
+#if defined( GAME_CSGO ) || defined( GAME_VITAMIN ) || defined( GAME_GMOD_64X )
 #define GAME_CSGO_OR_NEWER
 #define override_csgo override
 #define override_not_csgo
@@ -10,16 +22,7 @@
 #define override_not_csgo override
 #endif
 
-// GMod SDK2013 x86 branch
-#if defined( GAME_GMOD )
-#define override_gmod override
-#define override_not_gmod
-#else
-#define override_gmod
-#define override_not_gmod override
-#endif
-
-#if defined( GAME_CSGO ) || defined( GAME_VITAMIN ) || defined( GAME_PORTAL2 )
+#if defined( GAME_CSGO ) || defined( GAME_VITAMIN ) || defined( GAME_PORTAL2 ) || defined( GAME_GMOD_64X )
 #define GAME_PORTAL2_OR_NEWER
 #define override_portal2 override
 #define override_not_portal2
@@ -28,7 +31,7 @@
 #define override_not_portal2 override
 #endif
 
-#if defined( GAME_CSGO ) || defined( GAME_VITAMIN ) || defined( GAME_PORTAL2 ) || defined( GAME_L4D2 )
+#if defined( GAME_CSGO ) || defined( GAME_VITAMIN ) || defined( GAME_PORTAL2 ) || defined( GAME_L4D2 ) || defined( GAME_GMOD_64X )
 #define GAME_L4D2_OR_NEWER
 #define override_l4d2 override
 #define override_not_l4d2
@@ -37,7 +40,7 @@
 #define override_not_l4d2 override
 #endif
 
-#if defined( GAME_CSGO ) || defined( GAME_VITAMIN ) || defined( GAME_PORTAL2 ) || defined( GAME_L4D2 ) || defined( GAME_ASW )
+#if defined( GAME_CSGO ) || defined( GAME_VITAMIN ) || defined( GAME_PORTAL2 ) || defined( GAME_L4D2 ) || defined( GAME_ASW ) || defined( GAME_GMOD_64X )
 #define GAME_ASW_OR_NEWER
 #define override_asw override
 #define override_not_asw
@@ -50,7 +53,7 @@
 using strlen_t = int;
 #endif
 
-#ifndef GAME_CSGO_OR_NEWER
+#if !defined(GAME_CSGO_OR_NEWER) || defined( GAME_GMOD_64X )
 #define FastASCIIToUpper( c ) ( ( ( (c) >= 'a' ) && ( (c) <= 'z' ) ) ? ( (c) - 32 ) : (c) )
 #define FastASCIIToLower( c ) ( ( ( (c) >= 'A' ) && ( (c) <= 'Z' ) ) ? ( (c) + 32 ) : (c) )
 #endif

--- a/vphysics_jolt/compat/compat_sdk2013.h
+++ b/vphysics_jolt/compat/compat_sdk2013.h
@@ -5,7 +5,9 @@
 // Source Engine branches for SDK 2013.
 
 #include "Color.h"
+#include "branch_overrides.h"
 
+#if !defined( GAME_GMOD_64X )
 enum LoggingSeverity_t
 {
     LS_MESSAGE = 0,
@@ -14,6 +16,16 @@ enum LoggingSeverity_t
     LS_ERROR = 3,
     LS_HIGHEST_SEVERITY = 4,
 };
+
+static const int MAX_LOGGING_MESSAGE_LENGTH = 2048;
+#else
+#undef DECLARE_LOGGING_CHANNEL
+#undef DEFINE_LOGGING_CHANNEL_NO_TAGS
+#undef Log_Msg
+#undef Log_Warning
+#undef Log_Error
+#undef InternalMsg
+#endif
 
 struct LoggingChannelInfo_t
 {
@@ -27,8 +39,6 @@ struct LoggingChannelInfo_t
 
 #define DEFINE_LOGGING_CHANNEL_NO_TAGS( Channel, ChannelName, ...  ) LoggingChannelInfo_t g_LoggingInfo##Channel = { ChannelName, __VA_ARGS__ };
 
-static const int MAX_LOGGING_MESSAGE_LENGTH = 2048;
-
 // TODO
 #define DevAssert( ... )
 #define DevAssertMsg( ... )
@@ -39,11 +49,13 @@ static const int MAX_LOGGING_MESSAGE_LENGTH = 2048;
 #define Log_Error( Channel, Fmt, ... ) InternalMsg( Channel, Fmt, ##__VA_ARGS__ )
 
 // Unused, just makes stuff cleaner to not have ifdef spam.
+#if !defined( GAME_GMOD_64X )
 enum collisionhints
 {
     COLLISION_HINT_DEBRIS = 0x0001,
     COLLISION_HINT_STATICSOLID = 0x0002,
 };
+#endif
 
 class IPhysicsCollisionSet;
 class IPhysics;

--- a/vphysics_jolt/vjolt_controller_player.cpp
+++ b/vphysics_jolt/vjolt_controller_player.cpp
@@ -288,7 +288,8 @@ private:
 uint32 JoltPhysicsPlayerController::GetContactState( uint16 nGameFlags )
 {
 	// This does not seem to affect much, we should aspire to have our physics be as 1:1 to brush collisions as possible anyway
-#ifdef GAME_PORTAL2_OR_NEWER
+	// Raphael: I was getting stuck at the slightest touch with this enabled on 64x Gmod.
+#if defined( GAME_PORTAL2_OR_NEWER ) && !defined( GAME_GMOD )
 	if ( !m_pObject->IsCollisionEnabled() )
 		return 0;
 

--- a/vphysics_jolt/vjolt_controller_player.h
+++ b/vphysics_jolt/vjolt_controller_player.h
@@ -32,7 +32,11 @@ public:
 
 	bool WasFrozen() override;
 
+#if defined( GAME_GMOD_64X )
+	uint32 GetContactState( uint16 nGameFlags ); // Not a virtual in Gmod.
+#else
 	uint32 GetContactState( uint16 nGameFlags ) override_portal2;
+#endif
 
 	// IJoltObjectDestroyedListener
 	void OnJoltPhysicsObjectDestroyed( JoltPhysicsObject *pObject ) override;

--- a/vphysics_jolt/vjolt_environment.cpp
+++ b/vphysics_jolt/vjolt_environment.cpp
@@ -1117,10 +1117,14 @@ void JoltPhysicsEnvironment::PreRestore( const physprerestoreparams_t &params )
 {
 	m_SaveRestorePointerMap.clear();
 
+#if defined( GAME_GMOD_64X )
+	Log_Stub( LOG_VJolt ); // Raphael (ToDo): Figure out what happens here normally... I should check the SDK again and see if we have the previous structure used by all other branches.
+#else
 	for ( int i = 0; i < params.recreatedObjectCount; i++ )
 		AddPhysicsSaveRestorePointer(
 			reinterpret_cast< uintp >( params.recreatedObjectList[ i ].pOldObject ),
 			params.recreatedObjectList[ i ].pNewObject );
+#endif
 }
 
 bool JoltPhysicsEnvironment::Restore( const physrestoreparams_t &params )
@@ -1549,3 +1553,16 @@ void JoltPhysicsEnvironment::HandleDebugDumpingEnvironment( void *pReturnAddress
 	s_bShouldDumpEnvironmentClient = false;
 	s_bShouldDumpEnvironmentServer = false;
 }
+
+#if defined( GAME_GMOD_64X )
+// NOTE: physprerestoreparams_t was named to physpresaverestoreparams_t though we kept the original for now.
+void JoltPhysicsEnvironment::PreSave(const physprerestoreparams_t& params)
+{
+	Log_Stub( LOG_VJolt );
+}
+
+void JoltPhysicsEnvironment::PostSave()
+{
+	Log_Stub( LOG_VJolt );
+}
+#endif

--- a/vphysics_jolt/vjolt_environment.h
+++ b/vphysics_jolt/vjolt_environment.h
@@ -116,7 +116,13 @@ public:
 	void CleanupDeleteList() override;
 	void EnableDeleteQueue( bool enable ) override;
 
+#if defined( GAME_GMOD_64X )
+	void PreSave( const physprerestoreparams_t &params ) override;
+#endif
 	bool Save( const physsaveparams_t& params ) override;
+#if defined( GAME_GMOD_64X )
+	void PostSave() override;
+#endif
 	void PreRestore( const physprerestoreparams_t& params ) override;
 	bool Restore( const physrestoreparams_t& params ) override;
 	void PostRestore() override;

--- a/vphysics_jolt/vjolt_surfaceprops.cpp
+++ b/vphysics_jolt/vjolt_surfaceprops.cpp
@@ -237,7 +237,7 @@ KeyValues *JoltPhysicsSurfaceProps::SurfacePropsToKeyValues( const char *pszBuff
 }
 
 //-------------------------------------------------------------------------------------------------
-
+#if !defined( GAME_GMOD_64X )
 void *JoltPhysicsSurfaceProps::GetIVPMaterial( int nIndex )
 {
 	Log_Stub( LOG_VJolt );
@@ -267,6 +267,7 @@ const char *JoltPhysicsSurfaceProps::GetReservedMaterialName( int nMaterialIndex
 	Log_Stub( LOG_VJolt );
 	return "default";
 }
+#endif
 
 //-------------------------------------------------------------------------------------------------
 

--- a/vphysics_jolt/vjolt_surfaceprops.h
+++ b/vphysics_jolt/vjolt_surfaceprops.h
@@ -43,12 +43,14 @@ public:
 
 	ISaveRestoreOps		*GetMaterialIndexDataOps() const override_portal2;
 
+#if !defined( GAME_GMOD_64X )
 	// GMod-specific internal gubbins that was exposed in the public interface.
 	void				*GetIVPMaterial( int nIndex ) override_gmod;
 	int					GetIVPMaterialIndex( const void *pMaterial ) const override_gmod;
 	void				*GetIVPManager( void ) override_gmod;
 	int					RemapIVPMaterialIndex( int nIndex ) const override_gmod;
 	const char 			*GetReservedMaterialName( int nMaterialIndex ) const override_gmod;
+#endif
 
 public:
 	static JoltPhysicsSurfaceProps& GetInstance() { return s_PhysicsSurfaceProps; }

--- a/vphysics_wrapper/vphysics_wrapper.cpp
+++ b/vphysics_wrapper/vphysics_wrapper.cpp
@@ -32,6 +32,12 @@ public:
 	void Shutdown() override;
 	void *QueryInterface( const char *pInterfaceName ) override;
 
+#if PLATFORM_64BITS
+	const AppSystemInfo_t *GetDependencies( ) override { return NULL; };
+	AppSystemTier_t GetTier() override { return APP_SYSTEM_TIER2; };
+	void Reconnect( CreateInterfaceFn factory, const char *pInterfaceName ) override {};
+#endif
+
 	IPhysicsEnvironment *CreateEnvironment() override;
 	void DestroyEnvironment( IPhysicsEnvironment *pEnvironment ) override;
 	IPhysicsEnvironment *GetActiveEnvironmentByIndex( int index ) override;


### PR DESCRIPTION
Solves https://github.com/misyltoad/VPhysics-Jolt/issues/260
Requires https://github.com/misyltoad/mini-source-sdk/pull/5
Note: Linux 64x builds are broken due to GMod's magic libtier0 file - will need more time for that :/
Yes, you already iirc got 64x builds, though this would make it public.